### PR TITLE
tar archive support (--tar) for directories

### DIFF
--- a/lib/crypto/library/package.py
+++ b/lib/crypto/library/package.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os
+import tarfile
+from Naked.toolshed.file import FileReader
+from Naked.toolshed.system import make_path, stdout, stderr
+
+#------------------------------------------------------------------------------
+# PUBLIC
+#------------------------------------------------------------------------------
+def generate_tar_files(file_list):
+    """Public function that reads a list of local folders (or files) and generates tar archives from it"""
+    # this initial check may be removed as we previously already checked, if this file exists
+    # and if the user has moved it in the meantime, we will fail below anyway
+    for f in file_list:
+        if not os.path.exists(f):
+            stderr("Expected file/folder for tar archive creation did not exist.")
+            return False
+
+    tar_file_list = []
+
+    for f in file_list:
+        if _generate_tar(f):
+            tar_file_list.append(f+'.tar')
+
+    return tar_file_list
+
+def remove_tar_files(file_list):
+    for f in file_list:
+        if not os.path.exists(f) or not f.endswith('.tar'):
+            stderr("Expected tar archive not found.")
+            #continue
+        else:
+            os.remove(f)
+
+#------------------------------------------------------------------------------
+# PRIVATE
+#------------------------------------------------------------------------------
+def _generate_tar(filepath):
+    """Private function that reads a local folder (or file) and generates a tar archive from it"""
+    try:
+        with tarfile.open(filepath+'.tar', 'w') as tar:
+            tar.add(filepath)
+    except tarfile.TarError, e:
+        stderr("Error: TAR file creation failed [" + str(e) + "]")
+        return False
+
+    return True

--- a/lib/crypto/settings.py
+++ b/lib/crypto/settings.py
@@ -76,6 +76,7 @@ CRYPTO OPTIONS
    --hash                Generate SHA256 hash digest of encrypted file(s)
    --space               Favor reduced file size over encryption speed
    --speed               Favor encryption speed over reduced file size
+   --tar                 Create tar archives of folders before encryption
 
 DECRYPTO OPTIONS
    --overwrite | -o      Overwrite an existing file with the decrypted file


### PR DESCRIPTION
I added basic tar archiving support for folders before encryption. I know this could be done through other tools before using crypto, but for large folders it is very convenient to have it build right into crypto, since the user now doesn't have to wait for the tar archive creation to complete before starting the encryption.

For example, imagine you want to encrypt 100 folders, each 10 GB large. I could (and did) write a script, which would first tar the folders for me and then call crypto/gpg to do the encryption. The problem half-way down the line, I would have to enter the passcode for the encryption, which is inconvenient if I just want to start a larger batch-job. Building this into crypto allows me to first enter my passcode, then create the tar-archives and encrypt them right thereafter.

I also delete the tar archives after the encryption is done. Let me know what you think. Cheers.