### PR TITLE
Name encryption

### DIFF
--- a/lib/crypto/app.py
+++ b/lib/crypto/app.py
@@ -78,6 +78,11 @@ def main():
         if c.option('--tar'):
             tar_folders = True
 
+        ## ENCRYPT FILE NAMES
+        name_encryption = False
+        if c.option('--name') or c.option('-n'):
+            name_encryption = True
+
         directory_list = [] # directory paths included in the user entered paths from the command line
         tar_directory_list = [] # directories, which need to be packaged as tar archives
         file_list = [] # file paths included in the user entered paths from the command line (and inside directories entered)
@@ -155,18 +160,18 @@ def main():
                 # run encryption based upon any passed switches
                 if ascii_armored:
                     if max_compress:
-                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=True, armored=True, checksum=report_checksum)
+                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=True, armored=True, checksum=report_checksum, name_encryption=name_encryption)
                     elif no_compress:
-                        the_cryptor.encrypt_files(file_list, force_nocompress=True, force_compress=False, armored=True, checksum=report_checksum)
+                        the_cryptor.encrypt_files(file_list, force_nocompress=True, force_compress=False, armored=True, checksum=report_checksum, name_encryption=name_encryption)
                     else:
-                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=False, armored=True, checksum=report_checksum)
+                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=False, armored=True, checksum=report_checksum, name_encryption=name_encryption)
                 else:
                     if max_compress:
-                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=True, armored=False, checksum=report_checksum)
+                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=True, armored=False, checksum=report_checksum, name_encryption=name_encryption)
                     elif no_compress:
-                        the_cryptor.encrypt_files(file_list, force_nocompress=True, force_compress=False, armored=False, checksum=report_checksum)
+                        the_cryptor.encrypt_files(file_list, force_nocompress=True, force_compress=False, armored=False, checksum=report_checksum, name_encryption=name_encryption)
                     else:
-                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=False, armored=False, checksum=report_checksum)
+                        the_cryptor.encrypt_files(file_list, force_nocompress=False, force_compress=False, armored=False, checksum=report_checksum, name_encryption=name_encryption)
 
                 # overwrite user entered passphrases
                 passphrase = ""

--- a/lib/crypto/decryptoapp.py
+++ b/lib/crypto/decryptoapp.py
@@ -158,20 +158,48 @@ def main():
                         else: # decryption successful but we are in stdout flag so do not include any other output from decrypto
                             pass
                     else:
-                        system_command = "gpg --batch -o " + decrypted_filename + " --passphrase '" + passphrase + "' -d " + encrypted_file
-
                         if name_decryption:
-                            # for unknown reasons using -d option explicitly does not work, but since it is the default, it shouldn't be required
-                            # TODO: the following two commands can help decipher the encrypted name, if you want to be able to display it
+                            # new approach - extract the encrypted file name from package list and simply define it as the output name
+                            packets_command = "gpg --with-colons --list-packets --passphrase '" + passphrase + "' " + encrypted_file
+                            response = muterun(packets_command)
+                            response_stdout = response.stdout
+
+                            if ':literal data packet:' not in response_stdout or ', name=' not in response_stdout:
+                                stderr("Unable to decrypt filename from '" + encrypted_file + "'", 0)
+                            else:
+                                l_data_packet = response_stdout[response_stdout.rfind(':literal data packet:'):]
+                                l_data_packet = l_data_packet.replace(' ','')
+                                l_data_packet = l_data_packet.replace('\n','')
+                                l_data_packet = l_data_packet.replace('\t','')
+                                l_data_packet_split = l_data_packet.split(',')
+                                for l_data in l_data_packet_split:
+                                    if l_data.startswith('name="'):
+                                        l_file_name = l_data[6:-1]
+                                        if len(l_file_name) == 0:
+                                            stderr("Unable to decrypt filename from '" + encrypted_file + "'", 0)
+                                        else:
+                                            if os.path.sep in decrypted_filename:
+                                                decrypted_filename = make_path(decrypted_filename[:decrypted_filename.rfind(os.path.sep)],l_file_name)
+                                            else:
+                                                decrypted_filename = l_file_name
+                                        break
+
+                            # the following two commands can help decipher the encrypted name, if you want to be able to display it
                             #gpg --with-colons --list-packets foo.gpg
                             #gpg --status-fd 1 --use-embedded-filename foo.gpg
                             #decrypted_filename = 'decrypted_unknown_placeholder'
+
+                            '''
+                            # INITIAL idea
+                            # for unknown reasons using -d option explicitly does not work with --use-embedded-filename, but since '-d' is the default behaviour, it shouldn't be required
                             system_command = "gpg --batch --use-embedded-filename --passphrase '" + passphrase + "' " + encrypted_file
 
                             if use_file_overwrite:
                                 # gpg will query user to overwrite file, we will set the answer to yes
                                 system_command = "gpg --batch --use-embedded-filename --yes --passphrase '" + passphrase + "' " + encrypted_file
+                            '''
 
+                        system_command = "gpg --batch -o " + decrypted_filename + " --passphrase '" + passphrase + "' -d " + encrypted_file
                         response = muterun(system_command)
 
                         if response.exitcode == 0:

--- a/lib/crypto/library/cryptor.py
+++ b/lib/crypto/library/cryptor.py
@@ -103,7 +103,7 @@ class Cryptor(object):
         """private method that generates the crypto saved file path string with a .crypt file type"""
         if name_encryption:
             import uuid, os
-            filename_uuid = str(uuid.uuid4())
+            filename_uuid = str(uuid.uuid4().hex)
             if os.path.sep in inpath:
                 inpath = make_path(inpath[:inpath.rfind(os.path.sep)], filename_uuid)
             else:

--- a/lib/crypto/library/cryptor.py
+++ b/lib/crypto/library/cryptor.py
@@ -3,7 +3,7 @@
 
 import sys
 from Naked.toolshed.shell import muterun
-from Naked.toolshed.system import file_size, stdout, stderr
+from Naked.toolshed.system import file_size, stdout, stderr, make_path
 
 #------------------------------------------------------------------------------
 # Cryptor class

--- a/lib/crypto/settings.py
+++ b/lib/crypto/settings.py
@@ -82,10 +82,12 @@ CRYPTO OPTIONS
    --space               Favor reduced file size over encryption speed
    --speed               Favor encryption speed over reduced file size
    --tar                 Create tar archives of directories before encryption
+   --name  | -n          Encrypt file name embedded in a message
 
 DECRYPTO OPTIONS
    --overwrite | -o      Overwrite an existing file with the decrypted file
    --stdout    | -s      Print file contents to the standard output stream
+   --name      | -n      Decrypt and replace file name embedded inside the file
 
 OTHER OPTIONS
    --help | -h           Display crypto and decrypto help


### PR DESCRIPTION
I have done some basic testing and couldn't find any issues so far. I simply called this option "--name" for encryption as well as decryption. Some things to note:

1 - decryption without the --name flag will not try to decrypt the file name, but use the uuid instead. We could theoretically always check if there is an encrypted name present inside the file and then make this decryption more automatic? I do somehow prefer user-control for this, though. Not sure if this is the most intuitive. As a common user, I would probably expect that if I chose file-name encryption that the decryptor will automagically figure this out. What do you think?

2 - Any scenario where file names starting with numbers are a bad idea?

3 - The readme still needs to be adjusted to include the new option(s).