### PR TITLE
Escape command-line input (`quote`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ target/
 # Wing IDE local files (SHOULD commit .wpr files)
 *.wpu
 
+.idea
 workspace.xml

--- a/lib/crypto/decryptoapp.py
+++ b/lib/crypto/decryptoapp.py
@@ -17,6 +17,7 @@ def main():
     from Naked.commandline import Command
     from Naked.toolshed.shell import execute, muterun
     from Naked.toolshed.system import dir_exists, file_exists, list_all_files, make_path, stdout, stderr, is_dir
+    from shellescape import quote
 
     # ------------------------------------------------------------------------------------------
     # [ Instantiate command line object ]
@@ -146,7 +147,7 @@ def main():
                 # begin decryption
                 if not skip_file:
                     if use_standard_output:  # using --quiet flag to suppress stdout messages from gpg, just want the file data in stdout stream
-                        system_command = "gpg --batch --quiet --passphrase '" + passphrase + "' -d " + encrypted_file
+                        system_command = "gpg --batch --quiet --passphrase " + quote(passphrase) + " -d " + quote(encrypted_file)
                         successful_execution = execute(system_command)  # use naked execute function to directly push to stdout, rather than return stdout
 
                         if not successful_execution:
@@ -158,7 +159,7 @@ def main():
                         else:  # decryption successful but we are in stdout flag so do not include any other output from decrypto
                             pass
                     else:
-                        system_command = "gpg --batch -o " + decrypted_filename + " --passphrase '" + passphrase + "' -d " + encrypted_file
+                        system_command = "gpg --batch -o " + quote(decrypted_filename) + " --passphrase " + quote(passphrase) + " -d " + quote(encrypted_file)
                         response = muterun(system_command)
 
                         if response.exitcode == 0:
@@ -262,7 +263,7 @@ def main():
 
             # confirm that the passphrases match
             if passphrase == passphrase_confirm:
-                system_command = "gpg --batch -o " + decrypted_filename + " --passphrase '" + passphrase + "' -d " + path
+                system_command = "gpg --batch -o " + quote(decrypted_filename) + " --passphrase " + quote(passphrase) + " -d " + quote(path)
                 response = muterun(system_command)
 
                 if response.exitcode == 0:
@@ -342,7 +343,7 @@ def main():
                     if file_exists(decrypted_filepath):
                         stdout("The file path '" + decrypted_filepath + "' already exists.  This file was not decrypted.")
                     else:
-                        system_command = "gpg --batch -o " + decrypted_filepath + " --passphrase '" + passphrase + "' -d " + absolute_filepath
+                        system_command = "gpg --batch -o " + quote(decrypted_filepath) + " --passphrase " + quote(passphrase) + " -d " + quote(absolute_filepath)
                         response = muterun(system_command)
 
                         if response.exitcode == 0:

--- a/lib/crypto/library/cryptor.py
+++ b/lib/crypto/library/cryptor.py
@@ -5,6 +5,8 @@ import sys
 from Naked.toolshed.shell import muterun
 from Naked.toolshed.system import file_size, stdout, stderr
 
+from shellescape import quote
+
 # ------------------------------------------------------------------------------
 # Cryptor class
 #   performs gpg encryption of one or more files
@@ -55,7 +57,7 @@ class Cryptor(object):
                     command_stub = self.command_nocompress
 
         encrypted_outpath = self._create_outfilepath(inpath)
-        system_command = command_stub + encrypted_outpath + " --passphrase '" + self.passphrase + "' --symmetric " + inpath
+        system_command = command_stub + encrypted_outpath + " --passphrase " + quote(self.passphrase) + " --symmetric " + quote(inpath)
 
         try:
             response = muterun(system_command)
@@ -114,7 +116,8 @@ class Cryptor(object):
             if the_file_size > 10240:
                 if the_file_size > 512000:  # seems to be a break point at ~ 500kb where file compression offset by additional file read, so limit tests to files > 500kB
                     try:
-                        response = muterun("file --mime-type -b " + inpath)
+                        system_command = "file --mime-type -b " + quote(inpath)
+                        response = muterun(system_command)
                         if response.stdout[0:5] == "text/":  # check for a text file mime type
                             return True   # appropriate size, appropriate file mime type
                         else:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     },
     packages=find_packages("lib"),
     package_dir={'': 'lib'},
-    install_requires=['Naked'],
+    install_requires=['Naked', 'shellescape'],
     keywords='encryption,decryption,gpg,pgp,openpgp,cipher,AES256,crypto,cryptography,security,privacy',
     include_package_data=True,
     classifiers=[

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,6 +16,7 @@ MULTI_DIR="test_multi-directory.py"
 SINGLE_FILE="test_single-file.py"
 SINGLE_DIR="test_single-directory.py"
 UNICODE_PP="test_unicode-passphrase.py"
+ESCAPE_PP="test_escaping-passphrase.py"
 
 if [ "$1" = "all" ];then
 	"$TEST_COMMAND" "$NOSE_FLAGS" "$SINGLE_FILE" "$SINGLE_DIR"
@@ -43,6 +44,8 @@ elif [ "$1" = "single-dir" ];then
 	"$TEST_COMMAND" "$NOSE_FLAGS" "$SINGLE_DIR"
 elif [ "$1" = "unicode" ];then
 	"$TEST_COMMAND" "$NOSE_FLAGS" "$UNICODE_PP"
+elif [ "$1" = "escape" ];then
+	"$TEST_COMMAND" "$NOSE_FLAGS" "$ESCAPE_PP"
 else
 	echo "Enter 'all' or a command suite to test."
 	exit 1

--- a/tests/test_escaping-passphrase.py
+++ b/tests/test_escaping-passphrase.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+import sys
+import os
+import unittest
+import pexpect
+from Naked.toolshed.shell import execute
+from Naked.toolshed.system import file_exists, make_path
+
+class CryptoEscapePassphraseTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def submit_same_esc_passphrase(self, system_command):
+        child = pexpect.spawn(system_command)
+        #child.logfile = sys.stdout
+        child.expect("Please enter your passphrase: ")
+        child.sendline("$@`!\%^&*()_-+=3'A\\\'M'\W<>?,./|[]{}")
+        child.expect("Please enter your passphrase again: ")
+        child.sendline("$@`!\%^&*()_-+=3'A\\\'M'\W<>?,./|[]{}")
+        child.interact()
+        return child
+
+    def test_escape_passphrase_single_file_encrypt(self):
+        command = "crypto testdir11/esc_test.txt"
+        child = self.submit_same_esc_passphrase(command)
+        self.assertTrue(file_exists(make_path("testdir11", "esc_test.txt.crypt"))) #test that new encrypted file exists
+        child.close()
+
+        # cleanup
+        os.remove(make_path("testdir11","esc_test.txt.crypt"))
+
+    def test_escape_passphrase_multi_file_encrypt(self):
+        command = "crypto testdir11/esc_test.txt testdir11/esc_test2.txt"
+        child = self.submit_same_esc_passphrase(command)
+        self.assertTrue(file_exists(make_path("testdir11", "esc_test.txt.crypt"))) #test that new encrypted file exists
+        self.assertTrue(file_exists(make_path("testdir11", "esc_test2.txt.crypt"))) #test that new encrypted file exists
+        child.close()
+
+        # cleanup
+        os.remove(make_path("testdir11","esc_test.txt.crypt"))
+        os.remove(make_path("testdir11","esc_test2.txt.crypt"))
+
+    def test_escape_directory_encrypt(self):
+        command = "crypto testdir11"
+        child = self.submit_same_esc_passphrase(command)
+        self.assertTrue(file_exists(make_path("testdir11", "esc_test.txt.crypt"))) #test that new encrypted file exists
+        self.assertTrue(file_exists(make_path("testdir11", "esc_test2.txt.crypt"))) #test that new encrypted file exists
+        child.close()
+
+        # cleanup
+        os.remove(make_path("testdir11","esc_test.txt.crypt"))
+        os.remove(make_path("testdir11","esc_test2.txt.crypt"))
+
+

--- a/tests/testdir11/esc_test.txt
+++ b/tests/testdir11/esc_test.txt
@@ -1,0 +1,1 @@
+an escape unicode file with escaped $@`!\%^&*()_-+=3'A\\\'M'\W<>?,./|[]{}

--- a/tests/testdir11/esc_test2.txt
+++ b/tests/testdir11/esc_test2.txt
@@ -1,0 +1,1 @@
+another escape test file with more escapes $@`!\%^&*()_-+=3'A\\\'M'\W<>?,./|[]{}


### PR DESCRIPTION
As discussed in issue #8 command-line input should be `quote`(d) before passing it to a shell, which otherwise can be a serious security concern. This introduced [`shellescape`](https://github.com/chrissimpkins/shellescape) as a dependency to deal with this problem in a way compatible with `Python 2.x` and `3.x` (Note: right now [`shellescape`](https://github.com/chrissimpkins/shellescape) may need to be fixed for `Python 3.x`).